### PR TITLE
Allow Regular List Args as well as Keyword List Args

### DIFF
--- a/lib/graphql_builder.ex
+++ b/lib/graphql_builder.ex
@@ -116,14 +116,22 @@ defmodule GraphqlBuilder do
       is_binary(value) ->
         "#{key}: \"#{value}\""
 
-      is_list(value) ->
+      Keyword.keyword?(value) ->
         list = sub_variable_list(value)
         "#{key}: #{list}"
+
+      is_list(value) ->
+        joined_values = Enum.map_join(value, ",", &quote_if_binary/1)
+        "#{key}: [#{joined_values}]"
 
       true ->
         "#{key}: #{value}"
     end
   end
+
+  @spec quote_if_binary(any) :: any
+  defp quote_if_binary(string) when is_binary(string), do: "\"#{string}\""
+  defp quote_if_binary(not_string), do: not_string
 
   @spec sub_variable_list([atom | keyword]) :: String.t()
   defp sub_variable_list(variables) do

--- a/test/graphql_builder_test.exs
+++ b/test/graphql_builder_test.exs
@@ -66,6 +66,44 @@ defmodule GraphqlBuilderTest do
 
       assert GraphqlBuilder.query(query) == expected
     end
+
+    test "with integer lists" do
+      query = %Query{
+        operation: :thoughts,
+        fields: [:name, :thought],
+        variables: [ids: [12, 13]]
+      }
+
+      expected = """
+      query {
+        thoughts(ids: [12,13]) {
+          name,
+          thought
+        }
+      }
+      """
+
+      assert GraphqlBuilder.query(query) == expected
+    end
+
+    test "with string lists" do
+      query = %Query{
+        operation: :thoughts,
+        fields: [:name, :thought],
+        variables: [ids: ["12", "13"]]
+      }
+
+      expected = """
+      query {
+        thoughts(ids: ["12","13"]) {
+          name,
+          thought
+        }
+      }
+      """
+
+      assert GraphqlBuilder.query(query) == expected
+    end
   end
 
   describe "mutations" do


### PR DESCRIPTION
# What
The builder did not allow the user to pass lists of any type in as arguments. For example:
```
%Query{
  ...
  variables: [
    ids: [1, 2]
  ]
}
```

# What Changed?
Separated out the encoding of list lists from keyword lists in the builder

# Note
Thanks for building this! I would have liked to use `Jason.encode!` here, but I'm assuming you didn't want to add any dependencies.