### PR TITLE
Allow lists of objects in arguments

### DIFF
--- a/lib/graphql_builder.ex
+++ b/lib/graphql_builder.ex
@@ -123,7 +123,7 @@ defmodule GraphqlBuilder do
         "#{key}: #{list}"
 
       is_list(value) ->
-        joined_values = Enum.map_join(value, ",", &quote_if_binary/1)
+        joined_values = Enum.map_join(value, ", ", &value/1)
         "#{key}: [#{joined_values}]"
 
       true ->
@@ -131,9 +131,15 @@ defmodule GraphqlBuilder do
     end
   end
 
-  @spec quote_if_binary(any) :: any
-  defp quote_if_binary(string) when is_binary(string), do: inspect(string)
-  defp quote_if_binary(not_string), do: not_string
+  @spec value(any) :: any
+  defp value(val) when is_binary(val), do: inspect(val)
+  defp value(val) when is_map(val), do: "{#{Enum.map_join(val, ", ", &variable/1)}}"
+
+  defp value(val) do
+    if Keyword.keyword?(val),
+      do: "{#{Enum.map_join(val, ", ", &variable/1)}}",
+      else: val
+  end
 
   @spec sub_variable_list([atom | tuple]) :: String.t()
   defp sub_variable_list(variables) do

--- a/test/graphql_builder_test.exs
+++ b/test/graphql_builder_test.exs
@@ -76,7 +76,7 @@ defmodule GraphqlBuilderTest do
 
       expected = """
       query {
-        thoughts(ids: [12,13]) {
+        thoughts(ids: [12, 13]) {
           name,
           thought
         }
@@ -95,7 +95,7 @@ defmodule GraphqlBuilderTest do
 
       expected = """
       query {
-        thoughts(ids: ["12","13"]) {
+        thoughts(ids: ["12", "13"]) {
           name,
           thought
         }
@@ -167,6 +167,28 @@ defmodule GraphqlBuilderTest do
 
       assert GraphqlBuilder.mutation(query) == expected
     end
+  end
+
+  test "with nested lists of objects in mutation arguments" do
+    query = %Query{
+      operation: :update_breed,
+      variables: [
+        id: 12,
+        params: [things: [[num: 1], [num: "two"]]]
+      ],
+      fields: [:label, :abbreviation]
+    }
+
+    expected = """
+    mutation {
+      update_breed(id: 12, params: {things: [{num: 1}, {num: "two"}]}) {
+        label,
+        abbreviation
+      }
+    }
+    """
+
+    assert GraphqlBuilder.mutation(query) == expected
   end
 
   describe "subscriptions" do


### PR DESCRIPTION
Example:

```
%Query{
  operation: :update_breed,
  variables: [
    id: 12,
    params: [things: [[num: 1], [num: "two"]]]
  ],
  fields: [:label, :abbreviation]
}
```

This previously caused an error. Now it renders:

```
mutation {
  update_breed(id: 12, params: {things: [{num: 1}, {num: "two"}]}) {
    label,
    abbreviation
  }
}
```

I used a space after the comma in rendering the list as we have elsewhere. For consistency, I added a space in one existing place -- where lists are rendered. This meant fixing a couple tests and does cause cosmetic output differences vs before. If this is not desired, let me know.