### PR TITLE
Field args

### DIFF
--- a/lib/graphql_builder.ex
+++ b/lib/graphql_builder.ex
@@ -123,7 +123,7 @@ defmodule GraphqlBuilder do
         "#{key}: #{list}"
 
       is_list(value) ->
-        joined_values = Enum.map_join(value, ",", &quote_if_binary/1)
+        joined_values = Enum.map_join(value, ", ", &value/1)
         "#{key}: [#{joined_values}]"
 
       true ->
@@ -131,9 +131,15 @@ defmodule GraphqlBuilder do
     end
   end
 
-  @spec quote_if_binary(any) :: any
-  defp quote_if_binary(string) when is_binary(string), do: inspect(string)
-  defp quote_if_binary(not_string), do: not_string
+  @spec value(any) :: any
+  defp value(val) when is_binary(val), do: inspect(val)
+  defp value(val) when is_map(val), do: "{#{Enum.map_join(val, ", ", &variable/1)}}"
+
+  defp value(val) do
+    if Keyword.keyword?(val),
+      do: "{#{Enum.map_join(val, ", ", &variable/1)}}",
+      else: val
+  end
 
   @spec sub_variable_list([atom | tuple]) :: String.t()
   defp sub_variable_list(variables) do

--- a/mix.exs
+++ b/mix.exs
@@ -25,6 +25,7 @@ defmodule GraphqlBuilder.MixProject do
     [
       {:credo, "~> 1.0.0", only: [:dev, :test], runtime: false},
       {:dialyxir, "~> 1.0.0-rc.6", only: [:dev], runtime: false},
+      {:mix_test_watch, "~> 1.0", only: :dev, runtime: false},
       {:ex_doc, ">= 0.0.0", only: :dev, runtime: false}
     ]
   end

--- a/test/graphql_builder_test.exs
+++ b/test/graphql_builder_test.exs
@@ -11,8 +11,8 @@ defmodule GraphqlBuilderTest do
       expected = """
       query {
         thoughts {
-          id,
-          name,
+          id
+          name
           thought
         }
       }
@@ -30,14 +30,14 @@ defmodule GraphqlBuilderTest do
       expected = """
       query {
         orders {
-          id,
-          amount,
+          id
+          amount
           user {
-            id,
-            name,
-            email,
+            id
+            name
+            email
             address {
-              city,
+              city
               country
             }
           }
@@ -58,7 +58,7 @@ defmodule GraphqlBuilderTest do
       expected = """
       query {
         thoughts(id: 12) {
-          name,
+          name
           thought
         }
       }
@@ -77,7 +77,7 @@ defmodule GraphqlBuilderTest do
       expected = """
       query {
         thoughts(ids: [12, 13]) {
-          name,
+          name
           thought
         }
       }
@@ -96,7 +96,7 @@ defmodule GraphqlBuilderTest do
       expected = """
       query {
         thoughts(ids: ["12", "13"]) {
-          name,
+          name
           thought
         }
       }
@@ -159,7 +159,7 @@ defmodule GraphqlBuilderTest do
       expected = """
       mutation {
         update_breed(id: 12, params: {label: "label", abbreviation: "abbreviation"}) {
-          label,
+          label
           abbreviation
         }
       }
@@ -182,13 +182,34 @@ defmodule GraphqlBuilderTest do
     expected = """
     mutation {
       update_breed(id: 12, params: {things: [{num: 1}, {num: "two"}]}) {
-        label,
+        label
         abbreviation
       }
     }
     """
 
     assert GraphqlBuilder.mutation(query) == expected
+  end
+
+  test "with arguments on fields" do
+    query = %Query{
+      operation: :organization,
+      variables: [id: 4],
+      fields: [:name, locations: {[region: "west", nice: true], [:name]}]
+    }
+
+    expected = """
+    query {
+      organization(id: 4) {
+        name
+        locations(region: "west", nice: true) {
+          name
+        }
+      }
+    }
+    """
+
+    assert GraphqlBuilder.query(query) == expected
   end
 
   describe "subscriptions" do
@@ -220,7 +241,7 @@ defmodule GraphqlBuilderTest do
       expected = """
       subscription {
         breed_updated(id: 12) {
-          label,
+          label
           abbreviation
         }
       }

--- a/test/graphql_builder_test.exs
+++ b/test/graphql_builder_test.exs
@@ -76,7 +76,7 @@ defmodule GraphqlBuilderTest do
 
       expected = """
       query {
-        thoughts(ids: [12,13]) {
+        thoughts(ids: [12, 13]) {
           name,
           thought
         }
@@ -95,7 +95,7 @@ defmodule GraphqlBuilderTest do
 
       expected = """
       query {
-        thoughts(ids: ["12","13"]) {
+        thoughts(ids: ["12", "13"]) {
           name,
           thought
         }
@@ -167,6 +167,28 @@ defmodule GraphqlBuilderTest do
 
       assert GraphqlBuilder.mutation(query) == expected
     end
+  end
+
+  test "with nested lists of objects in mutation arguments" do
+    query = %Query{
+      operation: :update_breed,
+      variables: [
+        id: 12,
+        params: [things: [[num: 1], [num: "two"]]]
+      ],
+      fields: [:label, :abbreviation]
+    }
+
+    expected = """
+    mutation {
+      update_breed(id: 12, params: {things: [{num: 1}, {num: "two"}]}) {
+        label,
+        abbreviation
+      }
+    }
+    """
+
+    assert GraphqlBuilder.mutation(query) == expected
   end
 
   describe "subscriptions" do


### PR DESCRIPTION
This PR builds on top of #7 Allow lists of objects in arguments.

With this change, one can include parameters on a field as the unit test does for the `:locations` field. The trick is, instead of using a list of child fields, you use a two-element tuple. The first element is a keyword list of arguments, and the second is the list of fields.

```elixir
  test "with arguments on fields" do
    query = %Query{
      operation: :organization,
      variables: [id: 4],
      fields: [:name, locations: {[region: "west", nice: true], [:name]}]
    }

    expected = """
    query {
      organization(id: 4) {
        name
        locations(region: "west", nice: true) {
          name
        }
      }
    }
    """

    assert GraphqlBuilder.query(query) == expected
  end
```