### PR TITLE
Allow a map for variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,8 @@ iex> query = %Query{operation: :thoughts, fields: [:id, :name, :thought]}
 iex>  GraphqlBuilder.query(query)
 query {
   thoughts {
-    id,
-    name,
+    id
+    name
     thought
   }
 }
@@ -61,7 +61,7 @@ iex> query = %Query{
 iex> GraphqlBuilder.query(query)
 query {
   thoughts(id: 12) {
-    name,
+    name
     thought
   }
 }
@@ -79,14 +79,14 @@ iex> query = %Query{
 iex> GraphqlBuilder.query(query)
 query {
   orders {
-    id,
-    amount,
+    id
+    amount
     user {
-      id,
-      name,
-      email,
+      id
+      name
+      email
       address {
-        city,
+        city
         country
       }
     }
@@ -131,7 +131,7 @@ iex> query = %Query{
 iex> GraphqlBuilder.mutation(query)
 mutation {
   update_breed(id: 12, params: {label: "label", abbreviation: "abbreviation"}) {
-    label,
+    label
     abbreviation
   }
 }

--- a/lib/graphql_builder.ex
+++ b/lib/graphql_builder.ex
@@ -113,7 +113,7 @@ defmodule GraphqlBuilder do
     {acc, indent_level}
   end
 
-  @spec variable_list([{atom, any}] | nil) :: String.t()
+  @spec variable_list(keyword | map | nil) :: String.t()
   defp variable_list(nil) do
     ""
   end
@@ -132,7 +132,7 @@ defmodule GraphqlBuilder do
       [] == value ->
         "#{key}: []"
 
-      Keyword.keyword?(value) ->
+      Keyword.keyword?(value) or is_map(value) ->
         list = sub_variable_list(value)
         "#{key}: #{list}"
 
@@ -158,7 +158,7 @@ defmodule GraphqlBuilder do
       else: val
   end
 
-  @spec sub_variable_list([atom | tuple]) :: String.t()
+  @spec sub_variable_list(map | [atom | tuple]) :: String.t()
   defp sub_variable_list(variables) do
     str = Enum.map_join(variables, ", ", &variable/1)
     "{#{str}}"

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule GraphqlBuilder.MixProject do
   use Mix.Project
 
   @source_url "https://github.com/billperegoy/graphql_builder"
-  @version "0.3.3"
+  @version "0.3.4"
 
   def project do
     [

--- a/test/graphql_builder_test.exs
+++ b/test/graphql_builder_test.exs
@@ -86,6 +86,24 @@ defmodule GraphqlBuilderTest do
       assert GraphqlBuilder.query(query) == expected
     end
 
+    test "with empty object param" do
+      query = %Query{
+        operation: :thoughts,
+        fields: [:name],
+        variables: [params: %{}]
+      }
+
+      expected = """
+      query {
+        thoughts(params: {}) {
+          name
+        }
+      }
+      """
+
+      assert GraphqlBuilder.query(query) == expected
+    end
+
     test "with null param" do
       query = %Query{
         operation: :thoughts,


### PR DESCRIPTION
I noticed that there was no way to pass an empty object in variables. If I wrote

```elixir
%Query{
  operation: :thoughts,
  fields: [:name],
  variables: [params: []]
}
```

It would yield

```
query {
  thoughts(params: []) {
    name
  }
}
```

With this change, it is now possible to pass an empty map instead of an empty list. This would yield `params: {}` as I wanted.

Additionally, maps can now be used in general to build the params, if desired.