### PR TITLE
Support Enum as atoms

### DIFF
--- a/lib/graphql_builder.ex
+++ b/lib/graphql_builder.ex
@@ -143,6 +143,11 @@ defmodule GraphqlBuilder do
       is_nil(value) ->
         "#{key}: null"
 
+      # If the user specifies an atom (implicitly not nil (since that case is
+      # above this one), explicitly not true or false), assume it is an enum.
+      is_atom(value) and not is_boolean(value) ->
+        "#{key}: #{String.upcase(to_string(value))}"
+
       true ->
         "#{key}: #{value}"
     end

--- a/lib/graphql_builder.ex
+++ b/lib/graphql_builder.ex
@@ -143,11 +143,6 @@ defmodule GraphqlBuilder do
       is_nil(value) ->
         "#{key}: null"
 
-      # If the user specifies an atom (implicitly not nil (since that case is
-      # above this one), explicitly not true or false), assume it is an enum.
-      is_atom(value) and not is_boolean(value) ->
-        "#{key}: #{String.upcase(to_string(value))}"
-
       true ->
         "#{key}: #{value}"
     end

--- a/test/graphql_builder_test.exs
+++ b/test/graphql_builder_test.exs
@@ -122,6 +122,42 @@ defmodule GraphqlBuilderTest do
       assert GraphqlBuilder.query(query) == expected
     end
 
+    test "with boolean param" do
+      query = %Query{
+        operation: :thoughts,
+        fields: [:thought],
+        variables: [important: false]
+      }
+
+      expected = """
+      query {
+        thoughts(important: false) {
+          thought
+        }
+      }
+      """
+
+      assert GraphqlBuilder.query(query) == expected
+    end
+
+    test "with an atom param" do
+      query = %Query{
+        operation: :thoughts,
+        fields: [:thought],
+        variables: [type: :important]
+      }
+
+      expected = """
+      query {
+        thoughts(type: IMPORTANT) {
+          thought
+        }
+      }
+      """
+
+      assert GraphqlBuilder.query(query) == expected
+    end
+
     test "with integer lists" do
       query = %Query{
         operation: :thoughts,

--- a/test/graphql_builder_test.exs
+++ b/test/graphql_builder_test.exs
@@ -144,12 +144,48 @@ defmodule GraphqlBuilderTest do
       query = %Query{
         operation: :thoughts,
         fields: [:thought],
-        variables: [type: :important]
+        variables: [type: :IMPORTANT]
       }
 
       expected = """
       query {
         thoughts(type: IMPORTANT) {
+          thought
+        }
+      }
+      """
+
+      assert GraphqlBuilder.query(query) == expected
+    end
+
+    test "with a lower-case atom param" do
+      query = %Query{
+        operation: :thoughts,
+        fields: [:thought],
+        variables: [type: :important]
+      }
+
+      expected = """
+      query {
+        thoughts(type: important) {
+          thought
+        }
+      }
+      """
+
+      assert GraphqlBuilder.query(query) == expected
+    end
+
+    test "with a wacky-case atom param" do
+      query = %Query{
+        operation: :thoughts,
+        fields: [:thought],
+        variables: [type: :ImPorTaNt]
+      }
+
+      expected = """
+      query {
+        thoughts(type: ImPorTaNt) {
           thought
         }
       }


### PR DESCRIPTION
There is currently no way (that I know of) to use an enum in a query.  In this PR I propose that atoms that are not `nil`, `true`, or `false` (which have special meanings) be assumed to be enums, and formatted as such.

Curious as to your thoughts on this approach!